### PR TITLE
Fix for "E492: Not an editor command"

### DIFF
--- a/autoload/tagimposter.vim
+++ b/autoload/tagimposter.vim
@@ -28,8 +28,9 @@ function! tagimposter#pushtag(symbol)
     let tagfile = expand(fnamemodify(g:tagimposter_tagfile, ':p'))
 
     let symbol = g:tagimposter_symbolprefix . a:symbol
-    " Tags are a symbol, a file, and a search expression.
-    let tag_str = printf("%s\t%s\t/^%s$/;", symbol, expand("%:p"), getline('.'))
+    let tagaddress = '/^' . escape(getline('.'), '\/') . '$/'
+    " Tags are a symbol, a file, and a tagaddress (:h tags-file-format)
+    let tag_str = printf("%s\t%s\t%s;", symbol, expand("%:p"), tagaddress)
     let success = writefile([tag_str], tagfile, "S")
     if success >= 0
         exec 'tjump '. symbol


### PR DESCRIPTION
When `:TagImposterAnticipateJump` is called while cursor is on a line
which contains "/" character, "E492: Not an editor command" is raised.

For example, with the following file:

```
package main

import (
	"fmt"
)

func main() {
	fmt.Printf("Hello/World!")
}
```

When I call `:TagImposterAnticipateJump` while cursor is on `Printf`, I
get the following error:

```
Error detected while processing function tagimposter#pushtag:
line   11:
E492: Not an editor command: /^^Ifmt.Printf("Hello/World!")$/;
```

I made a change to escape "/" characters in the tagaddress section of
the tag line vim-tagimposter writes. I verified vim-tagimposter works
without throwing E492 with this change.

P.S. Thanks much for this super nice plugin. This is the killer plugin
which made me finally stick to LSP.